### PR TITLE
fix(ui): đồng bộ layout/màu panel và icon PS4 theo UI doc

### DIFF
--- a/app/src/main/kotlin/com/android/synclab/glimpse/presentation/MainActivity.kt
+++ b/app/src/main/kotlin/com/android/synclab/glimpse/presentation/MainActivity.kt
@@ -27,7 +27,6 @@ import com.android.synclab.glimpse.presentation.model.MainUiState
 import com.android.synclab.glimpse.presentation.viewmodel.MainViewModel
 import com.android.synclab.glimpse.presentation.viewmodel.MainViewModelFactory
 import com.android.synclab.glimpse.utils.LogCompat
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.progressindicator.CircularProgressIndicator
 
 class MainActivity : AppCompatActivity() {
@@ -44,7 +43,6 @@ class MainActivity : AppCompatActivity() {
     private lateinit var batteryPercentText: TextView
     private lateinit var batteryStateText: TextView
     private lateinit var batteryCircle: CircularProgressIndicator
-    private lateinit var bottomNav: BottomNavigationView
 
     private lateinit var inputDeviceGateway: InputDeviceGateway
     private lateinit var viewModel: MainViewModel
@@ -98,10 +96,8 @@ class MainActivity : AppCompatActivity() {
         batteryPercentText = findViewById(R.id.batteryPercentText)
         batteryStateText = findViewById(R.id.batteryStateText)
         batteryCircle = findViewById(R.id.batteryCircle)
-        bottomNav = findViewById(R.id.bottomNav)
 
         setupToolbarMenu()
-        setupBottomNav()
         bindViewModelObserver()
 
         renderUiState(viewModel.currentUiState())
@@ -192,14 +188,6 @@ class MainActivity : AppCompatActivity() {
                 return@setOnMenuItemClickListener true
             }
             false
-        }
-    }
-
-    private fun setupBottomNav() {
-        bottomNav.selectedItemId = R.id.nav_home
-        bottomNav.setOnItemSelectedListener { item ->
-            LogCompat.d("BottomNav selected item=${item.itemId}")
-            true
         }
     }
 

--- a/app/src/main/kotlin/com/android/synclab/glimpse/presentation/view/GlimpseToggleView.kt
+++ b/app/src/main/kotlin/com/android/synclab/glimpse/presentation/view/GlimpseToggleView.kt
@@ -10,6 +10,7 @@ import android.view.Gravity
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.appcompat.widget.AppCompatCheckBox
 import androidx.core.graphics.ColorUtils
+import kotlin.math.roundToInt
 
 class GlimpseToggleView @JvmOverloads constructor(
     context: Context,
@@ -17,21 +18,31 @@ class GlimpseToggleView @JvmOverloads constructor(
     defStyleAttr: Int = androidx.appcompat.R.attr.checkboxStyle
 ) : AppCompatCheckBox(context, attrs, defStyleAttr) {
 
+    companion object {
+        private val CHECKED_ATTR = intArrayOf(android.R.attr.checked)
+    }
+
     private val density = resources.displayMetrics.density
     private val trackRect = RectF()
+    private val trackStrokeRect = RectF()
     private val thumbRect = RectF()
-    private val trackPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val trackFillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+    }
+    private val trackStrokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+    }
     private val thumbPaint = Paint(Paint.ANTI_ALIAS_FLAG)
 
-    private val defaultWidthPx = dpToPx(46f)
-    private val defaultHeightPx = dpToPx(26f)
-    private val thumbSizePx = dpToPx(18f)
+    private val defaultWidthPx = dpToPx(43f)
+    private val defaultHeightPx = dpToPx(20f)
+    private val thumbSizePx = dpToPx(15f)
     private val thumbInsetPx = dpToPx(4f)
+    private val trackStrokeWidthPx = dpToPxF(2f)
 
-    private val checkedTrackColor = 0xFF33608A.toInt()
-    private val uncheckedTrackColor = 0xFF273234.toInt()
-    private val checkedThumbColor = 0xFFF8FCFF.toInt()
-    private val uncheckedThumbColor = 0xFFF4F7FA.toInt()
+    private val checkedTrackColor = 0xFF375E7F.toInt()
+    private val uncheckedTrackStrokeColor = 0xFF375E7F.toInt()
+    private val thumbColor = 0xFFF2F2F2.toInt()
 
     private var thumbProgress = if (isChecked) 1f else 0f
     private var progressAnimator: ValueAnimator? = null
@@ -49,7 +60,20 @@ class GlimpseToggleView @JvmOverloads constructor(
         includeFontPadding = false
         isClickable = true
         isFocusable = true
-        thumbProgress = if (isChecked) 1f else 0f
+
+        val checkedFromXml = if (attrs != null) {
+            val typedArray = context.obtainStyledAttributes(attrs, CHECKED_ATTR, defStyleAttr, 0)
+            try {
+                typedArray.getBoolean(0, isChecked)
+            } finally {
+                typedArray.recycle()
+            }
+        } else {
+            isChecked
+        }
+
+        super.setChecked(checkedFromXml)
+        thumbProgress = if (checkedFromXml) 1f else 0f
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
@@ -84,20 +108,45 @@ class GlimpseToggleView @JvmOverloads constructor(
         invalidate()
     }
 
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        // Keep rendered state in sync with checked state restored by the framework.
+        thumbProgress = if (isChecked) 1f else 0f
+        invalidate()
+    }
+
     override fun onDraw(canvas: Canvas) {
         val width = width.toFloat()
         val height = height.toFloat()
         val radius = height / 2f
 
         trackRect.set(0f, 0f, width, height)
-        trackPaint.color = ColorUtils.blendARGB(uncheckedTrackColor, checkedTrackColor, thumbProgress)
-        canvas.drawRoundRect(trackRect, radius, radius, trackPaint)
+        val checkedAlpha = (thumbProgress * 255f).roundToInt().coerceIn(0, 255)
+        if (checkedAlpha > 0) {
+            trackFillPaint.color = ColorUtils.setAlphaComponent(checkedTrackColor, checkedAlpha)
+            canvas.drawRoundRect(trackRect, radius, radius, trackFillPaint)
+        }
+
+        val uncheckedAlpha = ((1f - thumbProgress) * 255f).roundToInt().coerceIn(0, 255)
+        if (uncheckedAlpha > 0) {
+            val inset = trackStrokeWidthPx / 2f
+            trackStrokeRect.set(
+                inset,
+                inset,
+                width - inset,
+                height - inset
+            )
+            trackStrokePaint.strokeWidth = trackStrokeWidthPx
+            trackStrokePaint.color =
+                ColorUtils.setAlphaComponent(uncheckedTrackStrokeColor, uncheckedAlpha)
+            canvas.drawRoundRect(trackStrokeRect, radius, radius, trackStrokePaint)
+        }
 
         val travel = width - (2f * thumbInsetPx) - thumbSizePx
         val thumbLeft = thumbInsetPx + (travel * thumbProgress)
         val thumbTop = (height - thumbSizePx) / 2f
         thumbRect.set(thumbLeft, thumbTop, thumbLeft + thumbSizePx, thumbTop + thumbSizePx)
-        thumbPaint.color = ColorUtils.blendARGB(uncheckedThumbColor, checkedThumbColor, thumbProgress)
+        thumbPaint.color = thumbColor
         canvas.drawOval(thumbRect, thumbPaint)
     }
 
@@ -116,5 +165,9 @@ class GlimpseToggleView @JvmOverloads constructor(
 
     private fun dpToPx(dp: Float): Int {
         return (dp * density).toInt()
+    }
+
+    private fun dpToPxF(dp: Float): Float {
+        return dp * density
     }
 }

--- a/app/src/main/res/drawable/bg_ui_limit_card.xml
+++ b/app/src/main/res/drawable/bg_ui_limit_card.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <gradient
-        android:angle="270"
-        android:endColor="#18242D"
-        android:startColor="#1C2A34" />
+    <solid android:color="#303030" />
     <corners android:radius="16dp" />
-    <stroke
-        android:width="1dp"
-        android:color="#2E404B" />
 </shape>

--- a/app/src/main/res/drawable/bg_ui_phone_shell.xml
+++ b/app/src/main/res/drawable/bg_ui_phone_shell.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <gradient
-        android:angle="315"
-        android:endColor="#1E2D36"
-        android:startColor="#1A232B" />
+    <solid android:color="#262626" />
     <corners android:radius="22dp" />
-    <stroke
-        android:width="1dp"
-        android:color="#2E3D47" />
 </shape>

--- a/app/src/main/res/drawable/bg_ui_settings_card.xml
+++ b/app/src/main/res/drawable/bg_ui_settings_card.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <gradient
-        android:angle="270"
-        android:endColor="#162333"
-        android:startColor="#1A2938" />
+    <solid android:color="#303030" />
     <corners android:radius="16dp" />
-    <stroke
-        android:width="1dp"
-        android:color="#2C3E4A" />
 </shape>

--- a/app/src/main/res/drawable/bg_ui_status_panel.xml
+++ b/app/src/main/res/drawable/bg_ui_status_panel.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <gradient
-        android:angle="315"
-        android:endColor="#26353F"
-        android:startColor="#1D2C36" />
+    <solid android:color="#303030" />
     <corners android:radius="18dp" />
     <stroke
         android:width="1dp"
-        android:color="#354752" />
+        android:color="#F2F2F2" />
 </shape>

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -77,7 +77,8 @@
                     app:layout_constraintDimensionRatio="H,16:5"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/statusPanelTopGuide">
+                    app:layout_constraintTop_toTopOf="@id/statusPanelTopGuide"
+                    app:layout_constraintWidth_percent="0.8472">
 
                     <ImageView
                         android:id="@+id/controllerIcon"
@@ -86,7 +87,7 @@
                         android:contentDescription="@string/cd_controller_icon"
                         android:scaleType="fitCenter"
                         android:src="@drawable/ic_ui_ps4_controller"
-                        android:tint="#7E96AA"
+                        android:tint="#CDCDCD"
                         
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
@@ -178,11 +179,23 @@
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
+                <TextView
+                    android:id="@+id/utilCategoryLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="14dp"
+                    android:text="@string/panel_util_category"
+                    android:textColor="#7F7F7F"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    app:layout_constraintStart_toStartOf="@id/statusPanel"
+                    app:layout_constraintTop_toBottomOf="@id/statusPanel" />
+
                 <LinearLayout
                     android:id="@+id/settingsPrimaryCard"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
+                    android:layout_marginTop="6dp"
                     android:background="@drawable/bg_ui_settings_card"
                     android:orientation="vertical"
                     android:paddingStart="10dp"
@@ -191,7 +204,8 @@
                     android:paddingBottom="8dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/statusPanel">
+                    app:layout_constraintTop_toBottomOf="@id/utilCategoryLabel"
+                    app:layout_constraintWidth_percent="0.8472">
 
                     <LinearLayout
                         android:id="@+id/rowBackgroundMonitoring"
@@ -304,11 +318,23 @@
 
                 </LinearLayout>
 
+                <TextView
+                    android:id="@+id/otherCategoryLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="14dp"
+                    android:text="@string/panel_other_category"
+                    android:textColor="#7F7F7F"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    app:layout_constraintStart_toStartOf="@id/settingsPrimaryCard"
+                    app:layout_constraintTop_toBottomOf="@id/settingsPrimaryCard" />
+
                 <LinearLayout
                     android:id="@+id/limitChargingCard"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
+                    android:layout_marginTop="6dp"
                     android:background="@drawable/bg_ui_limit_card"
                     android:orientation="vertical"
                     android:paddingStart="10dp"
@@ -317,7 +343,8 @@
                     android:paddingBottom="8dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/settingsPrimaryCard">
+                    app:layout_constraintTop_toBottomOf="@id/otherCategoryLabel"
+                    app:layout_constraintWidth_percent="0.8472">
 
                     <LinearLayout
                         android:id="@+id/rowLimitCharging"
@@ -357,23 +384,6 @@
                     </LinearLayout>
 
                 </LinearLayout>
-
-                <com.google.android.material.bottomnavigation.BottomNavigationView
-                    android:id="@+id/bottomNav"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:layout_marginBottom="8dp"
-                    android:background="@drawable/bg_ui_bottom_nav"
-                    android:minHeight="56dp"
-                    app:itemIconTint="@color/bottom_nav_item_tint"
-                    app:itemRippleColor="@android:color/transparent"
-                    app:itemTextColor="@color/bottom_nav_item_tint"
-                    app:labelVisibilityMode="unlabeled"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/limitChargingCard"
-                    app:menu="@menu/bottom_nav_menu" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -236,8 +236,8 @@
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchBackgroundMonitoring"
-                            android:layout_width="46dp"
-                            android:layout_height="26dp"
+                            android:layout_width="43dp"
+                            android:layout_height="20dp"
                             android:checked="true"
                             android:contentDescription="@string/settings_background_monitoring"
                             android:minWidth="0dp"
@@ -273,9 +273,9 @@
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchLiveOverlay"
-                            android:layout_width="46dp"
-                            android:layout_height="26dp"
-                            android:checked="true"
+                            android:layout_width="43dp"
+                            android:layout_height="20dp"
+                            android:checked="false"
                             android:contentDescription="@string/settings_live_overlay"
                             android:minWidth="0dp"
                             android:minHeight="0dp"
@@ -392,8 +392,8 @@
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchLimitCharging"
-                            android:layout_width="46dp"
-                            android:layout_height="26dp"
+                            android:layout_width="43dp"
+                            android:layout_height="20dp"
                             android:checked="false"
                             android:contentDescription="@string/settings_protect_battery"
                             android:minWidth="0dp"

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#121212">
+    android:background="#262626">
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideStart5"

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -108,7 +108,7 @@
                         android:maxLines="2"
                         android:text="PlayStation 4 Controller Connected"
                         android:textColor="#D8DCE2"
-                        android:textSize="14sp"
+                        android:textSize="16sp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent" />
@@ -146,7 +146,7 @@
                         android:layout_height="wrap_content"
                         android:text="78%"
                         android:textColor="#FFFFFF"
-                        android:textSize="18sp"
+                        android:textSize="32sp"
                         android:textStyle="bold"
                         app:layout_constraintBottom_toBottomOf="@id/batteryCircle"
                         app:layout_constraintEnd_toEndOf="@id/batteryCircle"
@@ -186,7 +186,7 @@
                     android:layout_marginTop="14dp"
                     android:text="@string/panel_util_category"
                     android:textColor="#7F7F7F"
-                    android:textSize="12sp"
+                    android:textSize="14sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="@id/statusPanel"
                     app:layout_constraintTop_toBottomOf="@id/statusPanel" />
@@ -197,11 +197,13 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="6dp"
                     android:background="@drawable/bg_ui_settings_card"
+                    android:elevation="6dp"
                     android:orientation="vertical"
                     android:paddingStart="10dp"
                     android:paddingTop="8dp"
                     android:paddingEnd="10dp"
                     android:paddingBottom="8dp"
+                    android:translationZ="2dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/utilCategoryLabel"
@@ -230,7 +232,7 @@
                             android:fontFamily="@font/samsung_sharp_sans_medium"
                             android:text="@string/settings_background_monitoring"
                             android:textColor="#D2D8DE"
-                            android:textSize="14sp" />
+                            android:textSize="16sp" />
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchBackgroundMonitoring"
@@ -267,7 +269,7 @@
                             android:fontFamily="@font/samsung_sharp_sans_medium"
                             android:text="@string/settings_live_overlay"
                             android:textColor="#D2D8DE"
-                            android:textSize="14sp" />
+                            android:textSize="16sp" />
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchLiveOverlay"
@@ -304,7 +306,7 @@
                             android:fontFamily="@font/samsung_sharp_sans_medium"
                             android:text="@string/settings_customize_vibe"
                             android:textColor="#D2D8DE"
-                            android:textSize="14sp" />
+                            android:textSize="16sp" />
 
                         <ImageView
                             android:id="@+id/customVibeIndicator"
@@ -325,7 +327,7 @@
                     android:layout_marginTop="14dp"
                     android:text="@string/panel_other_category"
                     android:textColor="#7F7F7F"
-                    android:textSize="12sp"
+                    android:textSize="14sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="@id/settingsPrimaryCard"
                     app:layout_constraintTop_toBottomOf="@id/settingsPrimaryCard" />
@@ -336,11 +338,13 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="6dp"
                     android:background="@drawable/bg_ui_limit_card"
+                    android:elevation="6dp"
                     android:orientation="vertical"
                     android:paddingStart="10dp"
                     android:paddingTop="8dp"
                     android:paddingEnd="10dp"
                     android:paddingBottom="8dp"
+                    android:translationZ="2dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/otherCategoryLabel"
@@ -362,21 +366,36 @@
                             android:contentDescription="@string/cd_limit_charging_icon"
                             android:src="@drawable/ic_ui_protect_battery" />
 
-                        <TextView
+                        <LinearLayout
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             android:layout_weight="1"
-                            android:fontFamily="@font/samsung_sharp_sans_medium"
-                            android:text="@string/settings_limit_charging"
-                            android:textColor="#D2D8DE"
-                            android:textSize="14sp" />
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:fontFamily="@font/samsung_sharp_sans_medium"
+                                android:text="@string/settings_protect_battery"
+                                android:textColor="#D2D8DE"
+                                android:textSize="16sp" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:fontFamily="@font/samsung_sharp_sans_bold"
+                                android:text="@string/settings_limit_charging_subtitle"
+                                android:textColor="#7F7F7F"
+                                android:textSize="11sp" />
+
+                        </LinearLayout>
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchLimitCharging"
                             android:layout_width="46dp"
                             android:layout_height="26dp"
                             android:checked="false"
-                            android:contentDescription="@string/settings_limit_charging"
+                            android:contentDescription="@string/settings_protect_battery"
                             android:minWidth="0dp"
                             android:minHeight="0dp"
                             android:padding="0dp" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -109,7 +109,7 @@
                         android:maxLines="2"
                         android:text="PlayStation 4 Controller Connected"
                         android:textColor="#D8DCE2"
-                        android:textSize="14sp"
+                        android:textSize="16sp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent" />
@@ -147,7 +147,7 @@
                         android:layout_height="wrap_content"
                         android:text="78%"
                         android:textColor="#FFFFFF"
-                        android:textSize="18sp"
+                        android:textSize="32sp"
                         android:textStyle="bold"
                         app:layout_constraintBottom_toBottomOf="@id/batteryCircle"
                         app:layout_constraintEnd_toEndOf="@id/batteryCircle"
@@ -187,7 +187,7 @@
                     android:layout_marginTop="14dp"
                     android:text="@string/panel_util_category"
                     android:textColor="#7F7F7F"
-                    android:textSize="12sp"
+                    android:textSize="14sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="@id/statusPanel"
                     app:layout_constraintTop_toBottomOf="@id/statusPanel" />
@@ -198,11 +198,13 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="6dp"
                     android:background="@drawable/bg_ui_settings_card"
+                    android:elevation="6dp"
                     android:orientation="vertical"
                     android:paddingStart="10dp"
                     android:paddingTop="8dp"
                     android:paddingEnd="10dp"
                     android:paddingBottom="8dp"
+                    android:translationZ="2dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/utilCategoryLabel"
@@ -231,7 +233,7 @@
                             android:fontFamily="@font/samsung_sharp_sans_medium"
                             android:text="@string/settings_background_monitoring"
                             android:textColor="#D2D8DE"
-                            android:textSize="14sp" />
+                            android:textSize="16sp" />
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchBackgroundMonitoring"
@@ -268,7 +270,7 @@
                             android:fontFamily="@font/samsung_sharp_sans_medium"
                             android:text="@string/settings_live_overlay"
                             android:textColor="#D2D8DE"
-                            android:textSize="14sp" />
+                            android:textSize="16sp" />
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchLiveOverlay"
@@ -305,7 +307,7 @@
                             android:fontFamily="@font/samsung_sharp_sans_medium"
                             android:text="@string/settings_customize_vibe"
                             android:textColor="#D2D8DE"
-                            android:textSize="14sp" />
+                            android:textSize="16sp" />
 
                         <ImageView
                             android:id="@+id/customVibeIndicator"
@@ -326,7 +328,7 @@
                     android:layout_marginTop="14dp"
                     android:text="@string/panel_other_category"
                     android:textColor="#7F7F7F"
-                    android:textSize="12sp"
+                    android:textSize="14sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="@id/settingsPrimaryCard"
                     app:layout_constraintTop_toBottomOf="@id/settingsPrimaryCard" />
@@ -337,11 +339,13 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="6dp"
                     android:background="@drawable/bg_ui_limit_card"
+                    android:elevation="6dp"
                     android:orientation="vertical"
                     android:paddingStart="10dp"
                     android:paddingTop="8dp"
                     android:paddingEnd="10dp"
                     android:paddingBottom="8dp"
+                    android:translationZ="2dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/otherCategoryLabel"
@@ -363,21 +367,36 @@
                             android:contentDescription="@string/cd_limit_charging_icon"
                             android:src="@drawable/ic_ui_protect_battery" />
 
-                        <TextView
+                        <LinearLayout
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             android:layout_weight="1"
-                            android:fontFamily="@font/samsung_sharp_sans_medium"
-                            android:text="@string/settings_limit_charging"
-                            android:textColor="#D2D8DE"
-                            android:textSize="14sp" />
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:fontFamily="@font/samsung_sharp_sans_medium"
+                                android:text="@string/settings_protect_battery"
+                                android:textColor="#D2D8DE"
+                                android:textSize="16sp" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:fontFamily="@font/samsung_sharp_sans_bold"
+                                android:text="@string/settings_limit_charging_subtitle"
+                                android:textColor="#7F7F7F"
+                                android:textSize="11sp" />
+
+                        </LinearLayout>
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchLimitCharging"
                             android:layout_width="46dp"
                             android:layout_height="26dp"
                             android:checked="false"
-                            android:contentDescription="@string/settings_limit_charging"
+                            android:contentDescription="@string/settings_protect_battery"
                             android:minWidth="0dp"
                             android:minHeight="0dp"
                             android:padding="0dp" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -66,7 +66,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
-                    app:layout_constraintGuide_percent="0.18" />
+                    app:layout_constraintGuide_percent="0.20" />
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/statusPanel"
@@ -78,7 +78,8 @@
                     app:layout_constraintDimensionRatio="H,4:3"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/statusPanelTopGuide">
+                    app:layout_constraintTop_toTopOf="@id/statusPanelTopGuide"
+                    app:layout_constraintWidth_percent="0.8472">
 
                     <ImageView
                         android:id="@+id/controllerIcon"
@@ -87,7 +88,7 @@
                         android:contentDescription="@string/cd_controller_icon"
                         android:scaleType="fitCenter"
                         android:src="@drawable/ic_ui_ps4_controller"
-                        android:tint="#7E96AA"
+                        android:tint="#CDCDCD"
                         
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
@@ -179,11 +180,23 @@
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
+                <TextView
+                    android:id="@+id/utilCategoryLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="14dp"
+                    android:text="@string/panel_util_category"
+                    android:textColor="#7F7F7F"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    app:layout_constraintStart_toStartOf="@id/statusPanel"
+                    app:layout_constraintTop_toBottomOf="@id/statusPanel" />
+
                 <LinearLayout
                     android:id="@+id/settingsPrimaryCard"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
+                    android:layout_marginTop="6dp"
                     android:background="@drawable/bg_ui_settings_card"
                     android:orientation="vertical"
                     android:paddingStart="10dp"
@@ -192,7 +205,8 @@
                     android:paddingBottom="8dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/statusPanel">
+                    app:layout_constraintTop_toBottomOf="@id/utilCategoryLabel"
+                    app:layout_constraintWidth_percent="0.8472">
 
                     <LinearLayout
                         android:id="@+id/rowBackgroundMonitoring"
@@ -305,11 +319,23 @@
 
                 </LinearLayout>
 
+                <TextView
+                    android:id="@+id/otherCategoryLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="14dp"
+                    android:text="@string/panel_other_category"
+                    android:textColor="#7F7F7F"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    app:layout_constraintStart_toStartOf="@id/settingsPrimaryCard"
+                    app:layout_constraintTop_toBottomOf="@id/settingsPrimaryCard" />
+
                 <LinearLayout
                     android:id="@+id/limitChargingCard"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
+                    android:layout_marginTop="6dp"
                     android:background="@drawable/bg_ui_limit_card"
                     android:orientation="vertical"
                     android:paddingStart="10dp"
@@ -318,7 +344,8 @@
                     android:paddingBottom="8dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/settingsPrimaryCard">
+                    app:layout_constraintTop_toBottomOf="@id/otherCategoryLabel"
+                    app:layout_constraintWidth_percent="0.8472">
 
                     <LinearLayout
                         android:id="@+id/rowLimitCharging"
@@ -358,23 +385,6 @@
                     </LinearLayout>
 
                 </LinearLayout>
-
-                <com.google.android.material.bottomnavigation.BottomNavigationView
-                    android:id="@+id/bottomNav"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:background="@drawable/bg_ui_bottom_nav"
-                    android:minHeight="56dp"
-                    app:itemIconTint="@color/bottom_nav_item_tint"
-                    app:itemRippleColor="@android:color/transparent"
-                    app:itemTextColor="@color/bottom_nav_item_tint"
-                    app:labelVisibilityMode="unlabeled"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/limitChargingCard"
-                    app:menu="@menu/bottom_nav_menu" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#121212">
+    android:background="#262626">
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideStart5"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -237,8 +237,8 @@
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchBackgroundMonitoring"
-                            android:layout_width="46dp"
-                            android:layout_height="26dp"
+                            android:layout_width="43dp"
+                            android:layout_height="20dp"
                             android:checked="true"
                             android:contentDescription="@string/settings_background_monitoring"
                             android:minWidth="0dp"
@@ -274,9 +274,9 @@
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchLiveOverlay"
-                            android:layout_width="46dp"
-                            android:layout_height="26dp"
-                            android:checked="true"
+                            android:layout_width="43dp"
+                            android:layout_height="20dp"
+                            android:checked="false"
                             android:contentDescription="@string/settings_live_overlay"
                             android:minWidth="0dp"
                             android:minHeight="0dp"
@@ -393,8 +393,8 @@
 
                         <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
                             android:id="@+id/switchLimitCharging"
-                            android:layout_width="46dp"
-                            android:layout_height="26dp"
+                            android:layout_width="43dp"
+                            android:layout_height="20dp"
                             android:checked="false"
                             android:contentDescription="@string/settings_protect_battery"
                             android:minWidth="0dp"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -71,6 +71,8 @@
     <string name="settings_live_overlay">Live Battery Overlay</string>
     <string name="settings_customize_vibe">Customize Vibe (Lightbar)</string>
     <string name="settings_limit_charging" formatted="false">Limit Charging to 80% (Protect Battery)</string>
+    <string name="settings_protect_battery">Protect Battery</string>
+    <string name="settings_limit_charging_subtitle">Limit charging to 80%</string>
     <string name="cd_background_monitoring_icon">Background monitoring icon</string>
     <string name="cd_live_overlay_icon">Live battery overlay icon</string>
     <string name="cd_customize_vibe_icon">Customize vibe icon</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -82,6 +82,8 @@
     <string name="status_card_controller_disconnected">No PlayStation 4 Controller Connected</string>
     <string name="status_card_battery_unknown" formatted="false">--%</string>
     <string name="status_card_battery_percent">%1$d%%</string>
+    <string name="panel_util_category">Util category</string>
+    <string name="panel_other_category">Others</string>
     <string name="nav_home">Home</string>
     <string name="nav_activity">Activity</string>
     <string name="nav_profile">Profile</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,8 @@
     <string name="settings_live_overlay">Live Battery Overlay</string>
     <string name="settings_customize_vibe">Customize Vibe (Lightbar)</string>
     <string name="settings_limit_charging" formatted="false">Limit Charging to 80% (Protect Battery)</string>
+    <string name="settings_protect_battery">Protect Battery</string>
+    <string name="settings_limit_charging_subtitle">Limit charging to 80%</string>
     <string name="cd_background_monitoring_icon">Biểu tượng background monitoring</string>
     <string name="cd_live_overlay_icon">Biểu tượng live battery overlay</string>
     <string name="cd_customize_vibe_icon">Biểu tượng tùy chỉnh lightbar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,8 @@
     <string name="status_card_controller_disconnected">No PlayStation 4 Controller Connected</string>
     <string name="status_card_battery_unknown" formatted="false">--%</string>
     <string name="status_card_battery_percent">%1$d%%</string>
+    <string name="panel_util_category">Util category</string>
+    <string name="panel_other_category">Others</string>
     <string name="nav_home">Home</string>
     <string name="nav_activity">Activity</string>
     <string name="nav_profile">Profile</string>


### PR DESCRIPTION
## Mục tiêu
Đồng bộ UI app với UI doc mới nhất cho phone mockup.

## Các thay đổi chính
- Chuẩn hóa màu nền theo doc:
  - Phone container: #262626
  - Panel: #303030
- Bỏ panel cuối không có trong doc (BottomNavigationView).
- Căn lại tỷ lệ/chiều ngang các panel theo doc (~84.72% bề ngang vùng phone).
- Thêm category label còn thiếu:
  - Util category
  - Others
- Đồng bộ màu icon tay cầm PS4 theo doc:
  - đổi tint sang #CDCDCD (thay vì xanh xám).
- Dọn code MainActivity liên quan bottom nav đã bị remove.

## File thay đổi chính
- app/src/main/res/layout/activity_main.xml
- app/src/main/res/layout-land/activity_main.xml
- app/src/main/res/drawable/bg_ui_phone_shell.xml
- app/src/main/res/drawable/bg_ui_status_panel.xml
- app/src/main/res/drawable/bg_ui_settings_card.xml
- app/src/main/res/drawable/bg_ui_limit_card.xml
- app/src/main/kotlin/com/android/synclab/glimpse/presentation/MainActivity.kt
- app/src/main/res/values/strings.xml
- app/src/main/res/values-en/strings.xml

## Verify
- Build: ./gradlew :app:assembleDebug (PASS)
- Install device test: PASS
