### PR TITLE
feat(ui): refactor settings list and align main screen with UI doc

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,4 +34,5 @@ android {
 
 dependencies {
     implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
 }

--- a/app/src/main/kotlin/com/android/synclab/glimpse/presentation/MainActivity.kt
+++ b/app/src/main/kotlin/com/android/synclab/glimpse/presentation/MainActivity.kt
@@ -18,12 +18,16 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.android.synclab.glimpse.R
 import com.android.synclab.glimpse.data.model.BatteryChargeStatus
 import com.android.synclab.glimpse.di.AppContainer
 import com.android.synclab.glimpse.infra.input.InputDeviceGateway
 import com.android.synclab.glimpse.presentation.model.EventChangeParam
 import com.android.synclab.glimpse.presentation.model.MainUiState
+import com.android.synclab.glimpse.presentation.model.SettingItemUiModel
+import com.android.synclab.glimpse.presentation.view.SettingItemAdapter
 import com.android.synclab.glimpse.presentation.viewmodel.MainViewModel
 import com.android.synclab.glimpse.presentation.viewmodel.MainViewModelFactory
 import com.android.synclab.glimpse.utils.LogCompat
@@ -43,12 +47,17 @@ class MainActivity : AppCompatActivity() {
     private lateinit var batteryPercentText: TextView
     private lateinit var batteryStateText: TextView
     private lateinit var batteryCircle: CircularProgressIndicator
+    private lateinit var utilSettingsRecycler: RecyclerView
+    private lateinit var otherSettingsRecycler: RecyclerView
+    private lateinit var utilSettingsAdapter: SettingItemAdapter
+    private lateinit var otherSettingsAdapter: SettingItemAdapter
 
     private lateinit var inputDeviceGateway: InputDeviceGateway
     private lateinit var viewModel: MainViewModel
 
     private var pendingStartAfterNotificationPermission = false
     private var pendingStartAfterBluetoothPermission = false
+    private var protectBatteryEnabled = false
 
     private val periodicRefresh = object : Runnable {
         override fun run() {
@@ -96,8 +105,11 @@ class MainActivity : AppCompatActivity() {
         batteryPercentText = findViewById(R.id.batteryPercentText)
         batteryStateText = findViewById(R.id.batteryStateText)
         batteryCircle = findViewById(R.id.batteryCircle)
+        utilSettingsRecycler = findViewById(R.id.utilSettingsRecycler)
+        otherSettingsRecycler = findViewById(R.id.otherSettingsRecycler)
 
         setupToolbarMenu()
+        setupSettingsLists()
         bindViewModelObserver()
 
         renderUiState(viewModel.currentUiState())
@@ -189,6 +201,113 @@ class MainActivity : AppCompatActivity() {
             }
             false
         }
+    }
+
+    private fun setupSettingsLists() {
+        utilSettingsAdapter = SettingItemAdapter(
+            onToggleChanged = ::handleSettingToggleChanged,
+            onItemClicked = ::handleSettingItemClicked
+        )
+        otherSettingsAdapter = SettingItemAdapter(
+            onToggleChanged = ::handleSettingToggleChanged,
+            onItemClicked = ::handleSettingItemClicked
+        )
+
+        utilSettingsRecycler.layoutManager = LinearLayoutManager(this)
+        utilSettingsRecycler.adapter = utilSettingsAdapter
+        utilSettingsRecycler.itemAnimator = null
+        utilSettingsRecycler.isNestedScrollingEnabled = false
+
+        otherSettingsRecycler.layoutManager = LinearLayoutManager(this)
+        otherSettingsRecycler.adapter = otherSettingsAdapter
+        otherSettingsRecycler.itemAnimator = null
+        otherSettingsRecycler.isNestedScrollingEnabled = false
+
+        utilSettingsRecycler.addOnLayoutChangeListener { view, _, _, _, _, _, _, _, _ ->
+            utilSettingsAdapter.updateContainerHeight(view.height)
+        }
+        otherSettingsRecycler.addOnLayoutChangeListener { view, _, _, _, _, _, _, _, _ ->
+            otherSettingsAdapter.updateContainerHeight(view.height)
+        }
+
+        utilSettingsRecycler.post {
+            utilSettingsAdapter.updateContainerHeight(utilSettingsRecycler.height)
+        }
+        otherSettingsRecycler.post {
+            otherSettingsAdapter.updateContainerHeight(otherSettingsRecycler.height)
+        }
+    }
+
+    private fun handleSettingToggleChanged(
+        itemId: SettingItemUiModel.ItemId,
+        checked: Boolean
+    ) {
+        LogCompat.d("settingToggleChanged id=$itemId checked=$checked")
+        when (itemId) {
+            SettingItemUiModel.ItemId.BACKGROUND_MONITORING -> {
+                if (checked) {
+                    startMonitoring()
+                } else if (dispatchServiceAction(BatteryOverlayService.ACTION_STOP_MONITORING, false)) {
+                    showToast(R.string.toast_monitoring_stopped)
+                }
+            }
+
+            SettingItemUiModel.ItemId.LIVE_BATTERY_OVERLAY -> {
+                if (checked) {
+                    if (!Settings.canDrawOverlays(this)) {
+                        requestOverlayPermission()
+                        showToast(R.string.toast_overlay_permission_required)
+                        refreshSettingsStateLater(300L)
+                        return
+                    }
+                    if (dispatchServiceAction(BatteryOverlayService.ACTION_SHOW_OVERLAY, false)) {
+                        showToast(R.string.toast_overlay_shown)
+                    }
+                } else {
+                    if (!BatteryOverlayService.isRunning) {
+                        LogCompat.d("Ignore hide overlay because service is not running")
+                        refreshSettingsStateLater(200L)
+                        return
+                    }
+                    if (dispatchServiceAction(BatteryOverlayService.ACTION_HIDE_OVERLAY, false)) {
+                        showToast(R.string.toast_overlay_hidden)
+                    }
+                }
+            }
+
+            SettingItemUiModel.ItemId.PROTECT_BATTERY -> {
+                protectBatteryEnabled = checked
+            }
+
+            SettingItemUiModel.ItemId.CUSTOMIZE_VIBE -> {
+                // No toggle action for this item type.
+            }
+        }
+        refreshSettingsStateLater()
+    }
+
+    private fun handleSettingItemClicked(itemId: SettingItemUiModel.ItemId) {
+        LogCompat.d("settingItemClicked id=$itemId")
+        when (itemId) {
+            SettingItemUiModel.ItemId.CUSTOMIZE_VIBE -> {
+                // Placeholder for vibe customization action.
+            }
+
+            SettingItemUiModel.ItemId.BACKGROUND_MONITORING,
+            SettingItemUiModel.ItemId.LIVE_BATTERY_OVERLAY,
+            SettingItemUiModel.ItemId.PROTECT_BATTERY -> {
+                // Toggle rows are handled from onToggleChanged.
+            }
+        }
+    }
+
+    private fun refreshSettingsStateLater(delayMs: Long = 250L) {
+        mainHandler.postDelayed(
+            {
+                viewModel.syncServiceState(source = EventChangeParam.Source.VIEW)
+            },
+            delayMs
+        )
     }
 
     private fun showConfigDialog() {
@@ -462,6 +581,60 @@ class MainActivity : AppCompatActivity() {
         }
 
         updateBatteryUi(state.batteryPercent, state.batteryStatus)
+        renderSettingItems(state)
+    }
+
+    private fun renderSettingItems(state: MainUiState) {
+        if (!::utilSettingsAdapter.isInitialized || !::otherSettingsAdapter.isInitialized) {
+            return
+        }
+
+        utilSettingsAdapter.submitList(
+            listOf(
+                SettingItemUiModel(
+                    id = SettingItemUiModel.ItemId.BACKGROUND_MONITORING,
+                    iconRes = R.drawable.ic_ui_monitor,
+                    title = getString(R.string.settings_background_monitoring),
+                    control = SettingItemUiModel.Control.Toggle(
+                        checked = state.isMonitoringEnabled
+                    )
+                ),
+                SettingItemUiModel(
+                    id = SettingItemUiModel.ItemId.LIVE_BATTERY_OVERLAY,
+                    iconRes = R.drawable.ic_ui_overlay,
+                    title = getString(R.string.settings_live_overlay),
+                    control = SettingItemUiModel.Control.Toggle(
+                        checked = state.isOverlayVisible
+                    )
+                ),
+                SettingItemUiModel(
+                    id = SettingItemUiModel.ItemId.CUSTOMIZE_VIBE,
+                    iconRes = R.drawable.ic_ui_vibe,
+                    title = getString(R.string.settings_customize_vibe),
+                    control = SettingItemUiModel.Control.None
+                )
+            )
+        )
+        utilSettingsRecycler.post {
+            utilSettingsAdapter.updateContainerHeight(utilSettingsRecycler.height)
+        }
+
+        otherSettingsAdapter.submitList(
+            listOf(
+                SettingItemUiModel(
+                    id = SettingItemUiModel.ItemId.PROTECT_BATTERY,
+                    iconRes = R.drawable.ic_ui_protect_battery,
+                    title = getString(R.string.settings_protect_battery),
+                    subtitle = getString(R.string.settings_limit_charging_subtitle),
+                    control = SettingItemUiModel.Control.Toggle(
+                        checked = protectBatteryEnabled
+                    )
+                )
+            )
+        )
+        otherSettingsRecycler.post {
+            otherSettingsAdapter.updateContainerHeight(otherSettingsRecycler.height)
+        }
     }
 
     private fun updateBatteryUi(percent: Int?, status: BatteryChargeStatus) {

--- a/app/src/main/kotlin/com/android/synclab/glimpse/presentation/model/SettingItemUiModel.kt
+++ b/app/src/main/kotlin/com/android/synclab/glimpse/presentation/model/SettingItemUiModel.kt
@@ -1,0 +1,31 @@
+package com.android.synclab.glimpse.presentation.model
+
+import androidx.annotation.DrawableRes
+
+data class SettingItemUiModel(
+    val id: ItemId,
+    @DrawableRes val iconRes: Int,
+    val title: String,
+    val subtitle: String? = null,
+    val control: Control
+) {
+    enum class ItemId {
+        BACKGROUND_MONITORING,
+        LIVE_BATTERY_OVERLAY,
+        CUSTOMIZE_VIBE,
+        PROTECT_BATTERY
+    }
+
+    sealed interface Control {
+        data class Toggle(
+            val checked: Boolean,
+            val enabled: Boolean = true
+        ) : Control
+
+        data object None : Control
+
+        data object Indicator : Control
+
+        data class Action(@DrawableRes val iconRes: Int) : Control
+    }
+}

--- a/app/src/main/kotlin/com/android/synclab/glimpse/presentation/view/GlimpseToggleView.kt
+++ b/app/src/main/kotlin/com/android/synclab/glimpse/presentation/view/GlimpseToggleView.kt
@@ -34,10 +34,10 @@ class GlimpseToggleView @JvmOverloads constructor(
     }
     private val thumbPaint = Paint(Paint.ANTI_ALIAS_FLAG)
 
-    private val defaultWidthPx = dpToPx(43f)
-    private val defaultHeightPx = dpToPx(20f)
-    private val thumbSizePx = dpToPx(15f)
-    private val thumbInsetPx = dpToPx(4f)
+    private val defaultWidthPx = dpToPx(40f)
+    private val defaultHeightPx = dpToPx(18f)
+    private val thumbSizePx = dpToPx(14f)
+    private val thumbInsetPx = dpToPx(3f)
     private val trackStrokeWidthPx = dpToPxF(2f)
 
     private val checkedTrackColor = 0xFF375E7F.toInt()

--- a/app/src/main/kotlin/com/android/synclab/glimpse/presentation/view/SettingItemAdapter.kt
+++ b/app/src/main/kotlin/com/android/synclab/glimpse/presentation/view/SettingItemAdapter.kt
@@ -1,0 +1,199 @@
+package com.android.synclab.glimpse.presentation.view
+
+import android.view.HapticFeedbackConstants
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.android.synclab.glimpse.R
+import com.android.synclab.glimpse.presentation.model.SettingItemUiModel
+
+class SettingItemAdapter(
+    private val onToggleChanged: (SettingItemUiModel.ItemId, Boolean) -> Unit,
+    private val onItemClicked: (SettingItemUiModel.ItemId) -> Unit
+) : ListAdapter<SettingItemUiModel, SettingItemAdapter.SettingItemViewHolder>(DiffCallback) {
+
+    companion object {
+        private val DiffCallback = object : DiffUtil.ItemCallback<SettingItemUiModel>() {
+            override fun areItemsTheSame(
+                oldItem: SettingItemUiModel,
+                newItem: SettingItemUiModel
+            ): Boolean = oldItem.id == newItem.id
+
+            override fun areContentsTheSame(
+                oldItem: SettingItemUiModel,
+                newItem: SettingItemUiModel
+            ): Boolean = oldItem == newItem
+        }
+    }
+
+    private var containerHeightPx: Int = 0
+
+    fun updateContainerHeight(heightPx: Int) {
+        if (heightPx <= 0) {
+            return
+        }
+        containerHeightPx = heightPx
+        if (itemCount <= 0) {
+            return
+        }
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SettingItemViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_setting, parent, false)
+        return SettingItemViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: SettingItemViewHolder, position: Int) {
+        holder.bind(
+            item = getItem(position),
+            targetHeight = resolveItemHeight(),
+            position = position,
+            totalCount = itemCount
+        )
+    }
+
+    private fun resolveItemHeight(): Int? {
+        if (containerHeightPx <= 0 || itemCount <= 0) {
+            return null
+        }
+        return containerHeightPx / itemCount
+    }
+
+    inner class SettingItemViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        private val root: ConstraintLayout = view.findViewById(R.id.settingItemRoot)
+        private val icon: ImageView = view.findViewById(R.id.settingItemIcon)
+        private val title: TextView = view.findViewById(R.id.settingItemTitle)
+        private val subtitle: TextView = view.findViewById(R.id.settingItemSubtitle)
+        private val controlContainer: FrameLayout = view.findViewById(R.id.settingItemControlContainer)
+        private val toggle: GlimpseToggleView = view.findViewById(R.id.settingItemToggle)
+        private val indicator: ImageView = view.findViewById(R.id.settingItemIndicator)
+        private val actionIcon: ImageView = view.findViewById(R.id.settingItemActionIcon)
+        private val edgeInsetPx: Int =
+            (view.resources.displayMetrics.density * 10f).toInt()
+
+        private var boundItem: SettingItemUiModel? = null
+
+        init {
+            root.setOnClickListener {
+                val item = boundItem ?: return@setOnClickListener
+                when (item.control) {
+                    is SettingItemUiModel.Control.Toggle -> {
+                        toggle.performClick()
+                        it.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                    }
+
+                    is SettingItemUiModel.Control.None,
+                    is SettingItemUiModel.Control.Indicator,
+                    is SettingItemUiModel.Control.Action -> {
+                        onItemClicked(item.id)
+                        it.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                    }
+                }
+            }
+        }
+
+        fun bind(
+            item: SettingItemUiModel,
+            targetHeight: Int?,
+            position: Int,
+            totalCount: Int
+        ) {
+            boundItem = item
+            updateItemHeight(targetHeight)
+            applyEdgeStyle(position = position, totalCount = totalCount)
+
+            icon.setImageResource(item.iconRes)
+            title.text = item.title
+
+            val subtitleText = item.subtitle
+            if (subtitleText.isNullOrBlank()) {
+                subtitle.visibility = View.GONE
+                subtitle.text = ""
+            } else {
+                subtitle.visibility = View.VISIBLE
+                subtitle.text = subtitleText
+            }
+
+            toggle.visibility = View.GONE
+            indicator.visibility = View.GONE
+            actionIcon.visibility = View.GONE
+            controlContainer.isEnabled = true
+            controlContainer.visibility = View.VISIBLE
+
+            when (val control = item.control) {
+                is SettingItemUiModel.Control.Toggle -> {
+                    controlContainer.visibility = View.VISIBLE
+                    toggle.visibility = View.VISIBLE
+                    toggle.setOnCheckedChangeListener(null)
+                    toggle.isChecked = control.checked
+                    toggle.isEnabled = control.enabled
+                    toggle.setOnCheckedChangeListener { _, checked ->
+                        onToggleChanged(item.id, checked)
+                    }
+                }
+
+                is SettingItemUiModel.Control.None -> {
+                    controlContainer.visibility = View.GONE
+                }
+
+                is SettingItemUiModel.Control.Indicator -> {
+                    controlContainer.visibility = View.VISIBLE
+                    indicator.visibility = View.VISIBLE
+                }
+
+                is SettingItemUiModel.Control.Action -> {
+                    controlContainer.visibility = View.VISIBLE
+                    actionIcon.visibility = View.VISIBLE
+                    actionIcon.setImageResource(control.iconRes)
+                }
+            }
+        }
+
+        fun updateItemHeight(targetHeight: Int?) {
+            val desiredHeight = targetHeight ?: ViewGroup.LayoutParams.WRAP_CONTENT
+            val params = root.layoutParams
+            if (params.height == desiredHeight) {
+                return
+            }
+            params.height = desiredHeight
+            root.layoutParams = params
+        }
+
+        private fun applyEdgeStyle(position: Int, totalCount: Int) {
+            val isFirst = position == 0
+            val isLast = position == totalCount - 1
+
+            val rippleRes = when {
+                totalCount <= 1 -> R.drawable.ripple_setting_item_white_all
+                isFirst -> R.drawable.ripple_setting_item_white_top
+                isLast -> R.drawable.ripple_setting_item_white_bottom
+                else -> R.drawable.ripple_setting_item_white
+            }
+            root.foreground = AppCompatResources.getDrawable(root.context, rippleRes)
+
+            val topInset = when {
+                totalCount <= 1 -> 0
+                isFirst -> edgeInsetPx
+                else -> 0
+            }
+            val bottomInset = when {
+                totalCount <= 1 -> 0
+                isLast -> edgeInsetPx
+                else -> 0
+            }
+            if (root.paddingTop != topInset || root.paddingBottom != bottomInset) {
+                root.setPadding(0, topInset, 0, bottomInset)
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ripple_setting_item_white.xml
+++ b/app/src/main/res/drawable/ripple_setting_item_white.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#66FFFFFF">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="#FFFFFFFF" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable/ripple_setting_item_white_all.xml
+++ b/app/src/main/res/drawable/ripple_setting_item_white_all.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#66FFFFFF">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <corners android:radius="16dp" />
+            <solid android:color="#FFFFFFFF" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable/ripple_setting_item_white_bottom.xml
+++ b/app/src/main/res/drawable/ripple_setting_item_white_bottom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#66FFFFFF">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <corners
+                android:topLeftRadius="0dp"
+                android:topRightRadius="0dp"
+                android:bottomLeftRadius="16dp"
+                android:bottomRightRadius="16dp" />
+            <solid android:color="#FFFFFFFF" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable/ripple_setting_item_white_top.xml
+++ b/app/src/main/res/drawable/ripple_setting_item_white_top.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#66FFFFFF">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <corners
+                android:topLeftRadius="16dp"
+                android:topRightRadius="16dp"
+                android:bottomLeftRadius="0dp"
+                android:bottomRightRadius="0dp" />
+            <solid android:color="#FFFFFFFF" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -108,7 +108,7 @@
                         android:maxLines="2"
                         android:text="PlayStation 4 Controller Connected"
                         android:textColor="#D8DCE2"
-                        android:textSize="16sp"
+                        android:textSize="14sp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent" />
@@ -146,7 +146,7 @@
                         android:layout_height="wrap_content"
                         android:text="78%"
                         android:textColor="#FFFFFF"
-                        android:textSize="32sp"
+                        android:textSize="27sp"
                         android:textStyle="bold"
                         app:layout_constraintBottom_toBottomOf="@id/batteryCircle"
                         app:layout_constraintEnd_toEndOf="@id/batteryCircle"
@@ -160,7 +160,7 @@
                         android:layout_marginTop="2dp"
                         android:text="Charging"
                         android:textColor="#6FD5FF"
-                        android:textSize="11sp"
+                        android:textSize="9sp"
                         app:layout_constraintEnd_toEndOf="@id/batteryCircle"
                         app:layout_constraintStart_toStartOf="@id/batteryCircle"
                         app:layout_constraintTop_toBottomOf="@id/batteryPercentText" />
@@ -183,142 +183,41 @@
                     android:id="@+id/utilCategoryLabel"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="14dp"
+                    android:layout_marginTop="32dp"
                     android:text="@string/panel_util_category"
                     android:textColor="#7F7F7F"
-                    android:textSize="14sp"
+                    android:textSize="12sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="@id/statusPanel"
                     app:layout_constraintTop_toBottomOf="@id/statusPanel" />
 
-                <LinearLayout
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/settingsPrimaryCard"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="6dp"
+                    android:layout_height="0dp"
+                    android:layout_marginTop="12dp"
                     android:background="@drawable/bg_ui_settings_card"
                     android:elevation="6dp"
-                    android:orientation="vertical"
-                    android:paddingStart="10dp"
-                    android:paddingTop="8dp"
-                    android:paddingEnd="10dp"
-                    android:paddingBottom="8dp"
                     android:translationZ="2dp"
+                    app:layout_constraintDimensionRatio="H,4648200:2039112"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/utilCategoryLabel"
                     app:layout_constraintWidth_percent="0.8472">
 
-                    <LinearLayout
-                        android:id="@+id/rowBackgroundMonitoring"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:paddingTop="7dp"
-                        android:paddingBottom="7dp">
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/utilSettingsRecycler"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:nestedScrollingEnabled="false"
+                        android:overScrollMode="never"
+                        android:scrollbars="none"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
 
-                        <ImageView
-                            android:layout_width="22dp"
-                            android:layout_height="22dp"
-                            android:layout_marginEnd="10dp"
-                            android:contentDescription="@string/cd_background_monitoring_icon"
-                            android:src="@drawable/ic_ui_monitor" />
-
-                        <TextView
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:fontFamily="@font/samsung_sharp_sans_medium"
-                            android:text="@string/settings_background_monitoring"
-                            android:textColor="#D2D8DE"
-                            android:textSize="16sp" />
-
-                        <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
-                            android:id="@+id/switchBackgroundMonitoring"
-                            android:layout_width="43dp"
-                            android:layout_height="20dp"
-                            android:checked="true"
-                            android:contentDescription="@string/settings_background_monitoring"
-                            android:minWidth="0dp"
-                            android:minHeight="0dp"
-                            android:padding="0dp" />
-
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:id="@+id/rowLiveOverlay"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:paddingTop="7dp"
-                        android:paddingBottom="7dp">
-
-                        <ImageView
-                            android:layout_width="22dp"
-                            android:layout_height="22dp"
-                            android:layout_marginEnd="10dp"
-                            android:contentDescription="@string/cd_live_overlay_icon"
-                            android:src="@drawable/ic_ui_overlay" />
-
-                        <TextView
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:fontFamily="@font/samsung_sharp_sans_medium"
-                            android:text="@string/settings_live_overlay"
-                            android:textColor="#D2D8DE"
-                            android:textSize="16sp" />
-
-                        <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
-                            android:id="@+id/switchLiveOverlay"
-                            android:layout_width="43dp"
-                            android:layout_height="20dp"
-                            android:checked="false"
-                            android:contentDescription="@string/settings_live_overlay"
-                            android:minWidth="0dp"
-                            android:minHeight="0dp"
-                            android:padding="0dp" />
-
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:id="@+id/rowCustomizeVibe"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:paddingTop="7dp"
-                        android:paddingBottom="7dp">
-
-                        <ImageView
-                            android:layout_width="22dp"
-                            android:layout_height="22dp"
-                            android:layout_marginEnd="10dp"
-                            android:contentDescription="@string/cd_customize_vibe_icon"
-                            android:src="@drawable/ic_ui_vibe" />
-
-                        <TextView
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:fontFamily="@font/samsung_sharp_sans_medium"
-                            android:text="@string/settings_customize_vibe"
-                            android:textColor="#D2D8DE"
-                            android:textSize="16sp" />
-
-                        <ImageView
-                            android:id="@+id/customVibeIndicator"
-                            android:layout_width="20dp"
-                            android:layout_height="20dp"
-                            android:contentDescription="@string/cd_vibe_color_indicator"
-                            android:background="@drawable/bg_ui_vibe_indicator"
-                            android:padding="2dp" />
-
-                    </LinearLayout>
-
-                </LinearLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <TextView
                     android:id="@+id/otherCategoryLabel"
@@ -327,82 +226,38 @@
                     android:layout_marginTop="14dp"
                     android:text="@string/panel_other_category"
                     android:textColor="#7F7F7F"
-                    android:textSize="14sp"
+                    android:textSize="12sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="@id/settingsPrimaryCard"
                     app:layout_constraintTop_toBottomOf="@id/settingsPrimaryCard" />
 
-                <LinearLayout
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/limitChargingCard"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="0dp"
                     android:layout_marginTop="6dp"
                     android:background="@drawable/bg_ui_limit_card"
                     android:elevation="6dp"
-                    android:orientation="vertical"
-                    android:paddingStart="10dp"
-                    android:paddingTop="8dp"
-                    android:paddingEnd="10dp"
-                    android:paddingBottom="8dp"
                     android:translationZ="2dp"
+                    app:layout_constraintDimensionRatio="H,4648200:777240"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/otherCategoryLabel"
                     app:layout_constraintWidth_percent="0.8472">
 
-                    <LinearLayout
-                        android:id="@+id/rowLimitCharging"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:paddingTop="7dp"
-                        android:paddingBottom="7dp">
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/otherSettingsRecycler"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:nestedScrollingEnabled="false"
+                        android:overScrollMode="never"
+                        android:scrollbars="none"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
 
-                        <ImageView
-                            android:layout_width="22dp"
-                            android:layout_height="22dp"
-                            android:layout_marginEnd="10dp"
-                            android:contentDescription="@string/cd_limit_charging_icon"
-                            android:src="@drawable/ic_ui_protect_battery" />
-
-                        <LinearLayout
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:orientation="vertical">
-
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:fontFamily="@font/samsung_sharp_sans_medium"
-                                android:text="@string/settings_protect_battery"
-                                android:textColor="#D2D8DE"
-                                android:textSize="16sp" />
-
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:fontFamily="@font/samsung_sharp_sans_bold"
-                                android:text="@string/settings_limit_charging_subtitle"
-                                android:textColor="#7F7F7F"
-                                android:textSize="11sp" />
-
-                        </LinearLayout>
-
-                        <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
-                            android:id="@+id/switchLimitCharging"
-                            android:layout_width="43dp"
-                            android:layout_height="20dp"
-                            android:checked="false"
-                            android:contentDescription="@string/settings_protect_battery"
-                            android:minWidth="0dp"
-                            android:minHeight="0dp"
-                            android:padding="0dp" />
-
-                    </LinearLayout>
-
-                </LinearLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -109,7 +109,7 @@
                         android:maxLines="2"
                         android:text="PlayStation 4 Controller Connected"
                         android:textColor="#D8DCE2"
-                        android:textSize="16sp"
+                        android:textSize="14sp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent" />
@@ -147,7 +147,7 @@
                         android:layout_height="wrap_content"
                         android:text="78%"
                         android:textColor="#FFFFFF"
-                        android:textSize="32sp"
+                        android:textSize="27sp"
                         android:textStyle="bold"
                         app:layout_constraintBottom_toBottomOf="@id/batteryCircle"
                         app:layout_constraintEnd_toEndOf="@id/batteryCircle"
@@ -161,7 +161,7 @@
                         android:layout_marginTop="2dp"
                         android:text="Charging"
                         android:textColor="#6FD5FF"
-                        android:textSize="11sp"
+                        android:textSize="9sp"
                         app:layout_constraintEnd_toEndOf="@id/batteryCircle"
                         app:layout_constraintStart_toStartOf="@id/batteryCircle"
                         app:layout_constraintTop_toBottomOf="@id/batteryPercentText" />
@@ -184,142 +184,41 @@
                     android:id="@+id/utilCategoryLabel"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="14dp"
+                    android:layout_marginTop="32dp"
                     android:text="@string/panel_util_category"
                     android:textColor="#7F7F7F"
-                    android:textSize="14sp"
+                    android:textSize="12sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="@id/statusPanel"
                     app:layout_constraintTop_toBottomOf="@id/statusPanel" />
 
-                <LinearLayout
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/settingsPrimaryCard"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="6dp"
+                    android:layout_height="0dp"
+                    android:layout_marginTop="12dp"
                     android:background="@drawable/bg_ui_settings_card"
                     android:elevation="6dp"
-                    android:orientation="vertical"
-                    android:paddingStart="10dp"
-                    android:paddingTop="8dp"
-                    android:paddingEnd="10dp"
-                    android:paddingBottom="8dp"
                     android:translationZ="2dp"
+                    app:layout_constraintDimensionRatio="H,4648200:2039112"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/utilCategoryLabel"
                     app:layout_constraintWidth_percent="0.8472">
 
-                    <LinearLayout
-                        android:id="@+id/rowBackgroundMonitoring"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:paddingTop="7dp"
-                        android:paddingBottom="7dp">
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/utilSettingsRecycler"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:nestedScrollingEnabled="false"
+                        android:overScrollMode="never"
+                        android:scrollbars="none"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
 
-                        <ImageView
-                            android:layout_width="22dp"
-                            android:layout_height="22dp"
-                            android:layout_marginEnd="10dp"
-                            android:contentDescription="@string/cd_background_monitoring_icon"
-                            android:src="@drawable/ic_ui_monitor" />
-
-                        <TextView
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:fontFamily="@font/samsung_sharp_sans_medium"
-                            android:text="@string/settings_background_monitoring"
-                            android:textColor="#D2D8DE"
-                            android:textSize="16sp" />
-
-                        <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
-                            android:id="@+id/switchBackgroundMonitoring"
-                            android:layout_width="43dp"
-                            android:layout_height="20dp"
-                            android:checked="true"
-                            android:contentDescription="@string/settings_background_monitoring"
-                            android:minWidth="0dp"
-                            android:minHeight="0dp"
-                            android:padding="0dp" />
-
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:id="@+id/rowLiveOverlay"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:paddingTop="7dp"
-                        android:paddingBottom="7dp">
-
-                        <ImageView
-                            android:layout_width="22dp"
-                            android:layout_height="22dp"
-                            android:layout_marginEnd="10dp"
-                            android:contentDescription="@string/cd_live_overlay_icon"
-                            android:src="@drawable/ic_ui_overlay" />
-
-                        <TextView
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:fontFamily="@font/samsung_sharp_sans_medium"
-                            android:text="@string/settings_live_overlay"
-                            android:textColor="#D2D8DE"
-                            android:textSize="16sp" />
-
-                        <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
-                            android:id="@+id/switchLiveOverlay"
-                            android:layout_width="43dp"
-                            android:layout_height="20dp"
-                            android:checked="false"
-                            android:contentDescription="@string/settings_live_overlay"
-                            android:minWidth="0dp"
-                            android:minHeight="0dp"
-                            android:padding="0dp" />
-
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:id="@+id/rowCustomizeVibe"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:paddingTop="7dp"
-                        android:paddingBottom="7dp">
-
-                        <ImageView
-                            android:layout_width="22dp"
-                            android:layout_height="22dp"
-                            android:layout_marginEnd="10dp"
-                            android:contentDescription="@string/cd_customize_vibe_icon"
-                            android:src="@drawable/ic_ui_vibe" />
-
-                        <TextView
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:fontFamily="@font/samsung_sharp_sans_medium"
-                            android:text="@string/settings_customize_vibe"
-                            android:textColor="#D2D8DE"
-                            android:textSize="16sp" />
-
-                        <ImageView
-                            android:id="@+id/customVibeIndicator"
-                            android:layout_width="20dp"
-                            android:layout_height="20dp"
-                            android:contentDescription="@string/cd_vibe_color_indicator"
-                            android:background="@drawable/bg_ui_vibe_indicator"
-                            android:padding="2dp" />
-
-                    </LinearLayout>
-
-                </LinearLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <TextView
                     android:id="@+id/otherCategoryLabel"
@@ -328,82 +227,38 @@
                     android:layout_marginTop="14dp"
                     android:text="@string/panel_other_category"
                     android:textColor="#7F7F7F"
-                    android:textSize="14sp"
+                    android:textSize="12sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="@id/settingsPrimaryCard"
                     app:layout_constraintTop_toBottomOf="@id/settingsPrimaryCard" />
 
-                <LinearLayout
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/limitChargingCard"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="0dp"
                     android:layout_marginTop="6dp"
                     android:background="@drawable/bg_ui_limit_card"
                     android:elevation="6dp"
-                    android:orientation="vertical"
-                    android:paddingStart="10dp"
-                    android:paddingTop="8dp"
-                    android:paddingEnd="10dp"
-                    android:paddingBottom="8dp"
                     android:translationZ="2dp"
+                    app:layout_constraintDimensionRatio="H,4648200:777240"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/otherCategoryLabel"
                     app:layout_constraintWidth_percent="0.8472">
 
-                    <LinearLayout
-                        android:id="@+id/rowLimitCharging"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:paddingTop="7dp"
-                        android:paddingBottom="7dp">
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/otherSettingsRecycler"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:nestedScrollingEnabled="false"
+                        android:overScrollMode="never"
+                        android:scrollbars="none"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
 
-                        <ImageView
-                            android:layout_width="22dp"
-                            android:layout_height="22dp"
-                            android:layout_marginEnd="10dp"
-                            android:contentDescription="@string/cd_limit_charging_icon"
-                            android:src="@drawable/ic_ui_protect_battery" />
-
-                        <LinearLayout
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:orientation="vertical">
-
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:fontFamily="@font/samsung_sharp_sans_medium"
-                                android:text="@string/settings_protect_battery"
-                                android:textColor="#D2D8DE"
-                                android:textSize="16sp" />
-
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:fontFamily="@font/samsung_sharp_sans_bold"
-                                android:text="@string/settings_limit_charging_subtitle"
-                                android:textColor="#7F7F7F"
-                                android:textSize="11sp" />
-
-                        </LinearLayout>
-
-                        <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
-                            android:id="@+id/switchLimitCharging"
-                            android:layout_width="43dp"
-                            android:layout_height="20dp"
-                            android:checked="false"
-                            android:contentDescription="@string/settings_protect_battery"
-                            android:minWidth="0dp"
-                            android:minHeight="0dp"
-                            android:padding="0dp" />
-
-                    </LinearLayout>
-
-                </LinearLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/item_setting.xml
+++ b/app/src/main/res/layout/item_setting.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/settingItemRoot"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="@drawable/ripple_setting_item_white">
+
+    <ImageView
+        android:id="@+id/settingItemIcon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="10dp"
+        android:contentDescription="@null"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/settingItemTextContainer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/settingItemControlContainer"
+        app:layout_constraintStart_toEndOf="@id/settingItemIcon"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/settingItemTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:fontFamily="@font/samsung_sharp_sans_medium"
+            android:maxLines="1"
+            android:textColor="#D2D8DE"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/settingItemSubtitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="1dp"
+            android:includeFontPadding="true"
+            android:fontFamily="@font/samsung_sharp_sans_bold"
+            android:textColor="#7F7F7F"
+            android:textSize="9sp"
+            android:textStyle="bold"
+            android:visibility="gone" />
+    </LinearLayout>
+
+    <FrameLayout
+        android:id="@+id/settingItemControlContainer"
+        android:layout_width="40dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="10dp"
+        android:paddingTop="2dp"
+        android:paddingBottom="2dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.android.synclab.glimpse.presentation.view.GlimpseToggleView
+            android:id="@+id/settingItemToggle"
+            android:layout_width="40dp"
+            android:layout_height="18dp"
+            android:layout_gravity="center"
+            android:minWidth="0dp"
+            android:minHeight="0dp"
+            android:visibility="gone" />
+
+        <ImageView
+            android:id="@+id/settingItemIndicator"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_gravity="center"
+            android:background="@drawable/bg_ui_vibe_indicator"
+            android:contentDescription="@string/cd_vibe_color_indicator"
+            android:padding="2dp"
+            android:visibility="gone" />
+
+        <ImageView
+            android:id="@+id/settingItemActionIcon"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_gravity="center"
+            android:contentDescription="@null"
+            android:visibility="gone" />
+    </FrameLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -69,7 +69,7 @@
     <string name="unknown_controller_name">Gamepad</string>
     <string name="settings_background_monitoring">Background Monitoring</string>
     <string name="settings_live_overlay">Live Battery Overlay</string>
-    <string name="settings_customize_vibe">Customize Vibe (Lightbar)</string>
+    <string name="settings_customize_vibe">Customize Vibe</string>
     <string name="settings_limit_charging" formatted="false">Limit Charging to 80% (Protect Battery)</string>
     <string name="settings_protect_battery">Protect Battery</string>
     <string name="settings_limit_charging_subtitle">Limit charging to 80%</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@
     <string name="unknown_controller_name">Tay cầm</string>
     <string name="settings_background_monitoring">Background Monitoring</string>
     <string name="settings_live_overlay">Live Battery Overlay</string>
-    <string name="settings_customize_vibe">Customize Vibe (Lightbar)</string>
+    <string name="settings_customize_vibe">Customize Vibe</string>
     <string name="settings_limit_charging" formatted="false">Limit Charging to 80% (Protect Battery)</string>
     <string name="settings_protect_battery">Protect Battery</string>
     <string name="settings_limit_charging_subtitle">Limit charging to 80%</string>


### PR DESCRIPTION
## Mục tiêu
Đồng bộ lại khung UI MainActivity theo UI doc mới, đồng thời tách phần settings thành danh sách tái sử dụng để dễ maintain.

## Thay đổi chính
- Refactor settings panel từ layout hardcode sang RecyclerView + item reusable.
- Thêm SettingItemUiModel, SettingItemAdapter và item_setting.xml.
- Bổ sung ripple theo vị trí item (first/middle/last/single).
- Cập nhật MainActivity để render settings theo state.
- Customize Vibe hiển thị dạng item không control bên phải.
- Căn chỉnh spacing/margin theo UI doc (status panel -> Util category, Util category -> settings panel).
- Căn chỉnh typography theo rule đã chốt khi test (1pt = 0.85sp).
- Cập nhật values/values-en và wiring toggle.

## Verify
- Build: ./gradlew :app:assembleDebug
- Deploy test: chỉ cài lên device 10.192.141.20:5555